### PR TITLE
fix condition of taskIndex at updateTask, deleteTask

### DIFF
--- a/documents/1-graphql/README.md
+++ b/documents/1-graphql/README.md
@@ -518,7 +518,7 @@ export const TaskMutations = extendType({
       resolve: async (_parent, args) => {
         const taskIndex = TASKS.findIndex((task) => task.id === args.id)
 
-        if (taskIndex) {
+        if (taskIndex > -1) {
           if (args.content) {
             TASKS[taskIndex].content = args.content
           }
@@ -544,7 +544,7 @@ export const TaskMutations = extendType({
       resolve: async (_parent, args) => {
         const taskIndex = TASKS.findIndex((task) => task.id === args.id)
 
-        if (taskIndex) {
+        if (taskIndex > -1) {
           const task = TASKS[taskIndex]
           TASKS.splice(taskIndex, 1)
 


### PR DESCRIPTION
안녕하세요.

우선 serverless framework & next.js & prisma & prisma-nexus를 융합해서 핸즈온을 준비하시는 자혁님께 감탄하며 박수를 쳐드리고 싶습니다 👏👏👏👍👍 ㅎㅎ

저도 graphql과 prisma에 관심을 계속 두고 있던지라 잘 정리된 문서를 차근차근 보면서 스터디가 많이 되고 있는데요,

지금까지 실습 한 것 중에 사소한 버그가 있어서 PR을 올려봅니다 ㅎ
버그 내용은 아래에 정리 해 두겠습니다.

열심히 정독해서 핸즈온때는 자잘한 버그가 안 생기도록 노력 해 보겠습니다~ㅎ

감사합니다.

## schema/task/Mutation.ts updateTask & deleteTask
### 에러
- playground에서 `deleteTask`를 하면 에러가 나옴.
  - `mutation`
    ```
    mutation del {
      deleteTask(id: "gx54Ei6ZC7wDh7JAwV8uLV") {
        id
        content
      }
    }
    ```
  - `error`
    ```
    {
      "message": "gx54Ei6ZC7wDh7JAwV8uLV라는 ID를 가진 Task를 찾을 수 없습니다",
    }
    ```
### 원인
- resolver 분석: taskIndex가 0이면 if문에서 false와 같은 것으로 인지한다.
  - `schema/task/Mutation.ts`
    ```ts
    const taskIndex = TASKS.findIndex((task) => task.id === args.id)
    // taskIndex가 0이면 if문에서 false와 같은 것으로 인지한다.
    ```
### 수정
- taskIndex의 index가 -1 이상이면 원하는 값을 찾은 것이므로 if문의 조건을 `if (taskIndex > -1)` 으로 변경한다.
- `deleteTask`뿐만 아니라 `updateTask`도 동일한 로직이 있으므로 둘 다 고치도록 한다.
  ```ts
  const taskIndex = TASKS.findIndex((task) => task.id === args.id)
  - if (taskIndex) {
  + if (taskIndex > -1) {
  ```